### PR TITLE
Add TokenProxy::withdrawTo 

### DIFF
--- a/contracts/TokenProxy.sol
+++ b/contracts/TokenProxy.sol
@@ -108,14 +108,18 @@ contract TokenProxy is StandardToken {
     }
 
     function withdraw(uint256 _value) external {
+      withdrawTo(_value, msg.sender);
+    }
+
+    function withdrawTo(uint256 _value, address _destination) public {
         address user = msg.sender;
         uint256 balance = balances[user];
         require(_value <= balance);
 
-        balances[msg.sender] = (balance - _value);
+        balances[user] = (balance - _value);
         totalSupply_ -= _value;
 
-        TOKEN.transfer(user, _value);
+        TOKEN.transfer(_destination, _value);
 
         Burned(user, _value);
     }

--- a/tests/test_brass_concent.py
+++ b/tests/test_brass_concent.py
@@ -109,6 +109,18 @@ def test_windrawGNT(chain):
     assert gntb_balance + gnt_balance == gnt.call().balanceOf(owner_addr)
     assert 0 == gntb.call().balanceOf(owner_addr)
 
+def test_windrawTo(chain):
+    owner_addr, concent_addr, gnt, gntb, cdep = mysetup(chain)
+    recipient = tester.accounts[0]
+    assert owner_addr != recipient
+    gntb_balance = gntb.call().balanceOf(owner_addr)
+    assert gntb_balance > 0
+    gnt_balance = gnt.call().balanceOf(recipient)
+    chain.wait.for_receipt(
+        gntb.transact({'from': owner_addr}).withdrawTo(gntb_balance, recipient))
+    assert gntb_balance + gnt_balance == gnt.call().balanceOf(recipient)
+    assert 0 == gntb.call().balanceOf(owner_addr)
+
 
 def test_timelocks(chain):
     attacker = tester.accounts[1]


### PR DESCRIPTION
So we can do the equivalent of the following in one transaction instead of two:
```
TokenProxy::withdraw(_value);
GNTToken.transfer(_destination, _value);
```